### PR TITLE
g4: init: ril-daemon: Add a 5 seconds timer before executing the script

### DIFF
--- a/rootdir/etc/init.qcom.post_boot.sh
+++ b/rootdir/etc/init.qcom.post_boot.sh
@@ -203,14 +203,21 @@ if [ -c /dev/coresight-stm ]; then
 fi
 
 # sfX && kessaras: workaround for randomly no SIM on boot
-REQRESTART=$(getprop gsm.sim.operator.iso-country)
+sleep 5
+x=1
+REQRESTART=$(getprop gsm.sim.state)
 while [ -z "$REQRESTART" ]
 do
     stop ril-daemon
     start ril-daemon
-    echo "$0: restarted RIL daemon as gsm.sim.operator.iso-country was empty" >> /dev/kmsg
-    sleep 20
-    REQRESTART=$(getprop gsm.sim.operator.iso-country)
+    echo "$0: restarted RIL daemon as gsm.sim.state was empty" >> /dev/kmsg
+    sleep 10
+    REQRESTART=$(getprop gsm.sim.state)
+    x=$((x + 1))
+    if [[ $x -eq 10 ]]
+    then
+        break #For those that do not use the phone with a sim, after 10 tries to fix ril exit the loop.
+    fi
 done
 echo "$0: ended" >> /dev/kmsg
 # < END workaround


### PR DESCRIPTION
The reason is because boot time differs from device to device

Add a break to stop the loop after 10 tries.
This works best for those that use the phone without a sim installed.

Use prop gsm.sim.state instead. It's more accurate.

Change-Id: I9d699070041b5357a3a9a26d353e02e7af12064a